### PR TITLE
Fix: disklessset - regenerate boot.ipxe when changing kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 1.0.0 - Next-release
 
-  - Also update initramfs when updating image kernel (#2)
+  - Also update initramfs and regenerate boot.ipxe when updating image kernel (#2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 1.0.0 - Next-release
 
-  - change (#PR NUMBER)
+  - Also update initramfs when updating image kernel (#2)

--- a/disklessset/diskless/kernel_manager.py
+++ b/disklessset/diskless/kernel_manager.py
@@ -77,6 +77,8 @@ class KernelManager:
 
         # Use image method to set kernel
         image.kernel = kernel
+        # Update initramfs for selected kernel
+        image.image = 'initramfs-kernel-' + kernel.replace('vmlinuz-', '')
         # Register image with new kernel
         image.register_image()
 

--- a/disklessset/diskless/kernel_manager.py
+++ b/disklessset/diskless/kernel_manager.py
@@ -79,6 +79,8 @@ class KernelManager:
         image.kernel = kernel
         # Update initramfs for selected kernel
         image.image = 'initramfs-kernel-' + kernel.replace('vmlinuz-', '')
+        # Regenarate ipxe boot for the image
+        image.generate_ipxe_boot_file()
         # Register image with new kernel
         image.register_image()
 


### PR DESCRIPTION
Option 4 from disklessset is not updating initramfs image_data.yml nor regenerating boot.ipxe when changing kernels. 