### PR TITLE
Fix: disklessset - + kernel-modules to std livenet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## 1.0.0 - Next-release
 
+  - Added kernel-modules package to the standard livenet image type (#3)
   - More direct confirmation request message in disklessset menu options 3/7 (#1)

--- a/disklessset/diskless/livenet_module.py
+++ b/disklessset/diskless/livenet_module.py
@@ -157,8 +157,8 @@ class LivenetImage(Image):
 
         # Get appropriate packages for desired image file system
         if self.livenet_type == LivenetImage.Type.STANDARD:
-            logging.debug('Standard image requested. Adding "@core" to packages list')
-            dnf_packages = '@core'
+            logging.debug('Standard image requested. Adding "@core kernel-modules" to packages list')
+            dnf_packages = '@core kernel-modules'
 
         elif self.livenet_type == LivenetImage.Type.SMALL:
             logging.debug('Small image requested. Adding "dnf yum iproute procps-ng openssh-server NetworkManager" to packages list')
@@ -738,10 +738,10 @@ def cli_create_livenet_image():
     selected_password = input('Enter clear root password of the new image: ').replace(" ", "")
 
     # Select livenet type
-    types_list = ['Standard: core (~1.3Gb)', 'Small: openssh, dnf and NetworkManager (~300Mb)', 'Minimal: openssh only (~270Mb)']
+    types_list = ['Standard: core and kernel-modules (~1.3Gb)', 'Small: openssh, dnf and NetworkManager (~300Mb)', 'Minimal: openssh only (~270Mb)']
     get_type = select_from_list(types_list)
 
-    if get_type == 'Standard: core (~1.3Gb)':
+    if get_type == 'Standard: core and kernel-modules (~1.3Gb)':
         selected_type = LivenetImage.Type.STANDARD
     elif get_type == 'Small: openssh, dnf and NetworkManager (~300Mb)':
         selected_type = LivenetImage.Type.SMALL


### PR DESCRIPTION
kernel-modules is a quite basic package that is almost always manually typed by the users.
Besides that, for some reason the firewalld service, which is included in the core group, doesn't work without it.
I propose it to become part of the standard livenet image type.

This would require an update in doc:
https://github.com/bluebanquise/websites/tree/main/bluebanquise/documentation/roles/addons/diskless