### PR TITLE
Fix: disklessset - images created with selinux enabled don't boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0 - Next-release
 
+  - Fix livenet selinux enabled images not booting properly (#4)
   - Added kernel-modules package to the standard livenet image type (#3)
   - Update initramfs in image_data and regenerate boot.ipxe when changing kernel (#2)
   - More direct confirmation request message in disklessset menu options 3/7 (#1)

--- a/disklessset/diskless/livenet_module.py
+++ b/disklessset/diskless/livenet_module.py
@@ -219,8 +219,8 @@ class LivenetImage(Image):
         os.system('mount -o loop ' + self.IMAGE_DIRECTORY + 'tosquash/LiveOS/rootfs.img ' + self.MOUNT_DIRECTORY)
 
         # Put the operating system inside rootfs.img
-        logging.debug('Executing \'cp -a ' + self.WORKING_DIRECTORY + 'generated_os/* ' + self.MOUNT_DIRECTORY + '\'')
-        os.system('cp -a ' + self.WORKING_DIRECTORY + 'generated_os/* ' + self.MOUNT_DIRECTORY)
+        logging.debug('Executing \'cp -a ' + self.WORKING_DIRECTORY + 'generated_os/. ' + self.MOUNT_DIRECTORY + '\'')
+        os.system('cp -a ' + self.WORKING_DIRECTORY + 'generated_os/. ' + self.MOUNT_DIRECTORY)
 
         # Unmount rootfs.img file
         logging.debug('Executing \'umount ' + self.MOUNT_DIRECTORY + '\'')


### PR DESCRIPTION
The cp command was not preserving the context of / directory in destination.