### PR TITLE
Fix: disklessset - check image mount status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0
 
   - Feat: Add custom htdocs_path for bootset (#18)
+  - Fix: disklessset check if image is mounted (#19)
 
 ## 1.5.0
 

--- a/bluebanquise-disklessset/diskless/image_manager.py
+++ b/bluebanquise-disklessset/diskless/image_manager.py
@@ -156,6 +156,12 @@ class ImageManager:
             # Use the constructor of the image class to create fresh image object by it's name
             image = image_class(image_name)
 
+            # Checks if image is really mounted as per is_mounted = True
+            if image.is_mounted:
+                if not os.path.ismount(image.MOUNT_DIRECTORY):
+                    image.is_mounted = False
+                    image.register_image()
+
             # Return constructed image object
             return image
 

--- a/bluebanquise-disklessset/disklessset
+++ b/bluebanquise-disklessset/disklessset
@@ -10,6 +10,7 @@
 # disklessset script:
 #    This python script allows to create and manage diskless
 #    images from a linux command line interface.
+# 1.3.7: Improved disklessset checks. Thiago Cardozo <thiago_cardozo@yahoo.com.br>
 # 1.3.6: Fix permissions. Benoit Leveugle <benoit.leveugle@gmail.com>
 # 1.3.5: Stop tool if cannot umount image. Benoit Leveugle <benoit.leveugle@gmail.com>
 # 1.3.4: Removed dependency exclusions that break image builds. Thiago Cardozo <thiago_cardozo@yahoo.com.br>

--- a/versions.conf
+++ b/versions.conf
@@ -1,3 +1,3 @@
 bluebanquise_filters_version=1.0.3
 bluebanquise_bootset_version=1.0.6
-bluebanquise_disklessset_version=1.3.6
+bluebanquise_disklessset_version=1.3.7


### PR DESCRIPTION
If the mounted image host is shutdown or crashes, the mount status remains as mounted in the image metadata file.

This PR adds a check to verify that the image is really mounted.