### PR TITLE
added self.is_mounted=False To Nfs Classes

### DIFF
--- a/bluebanquise-disklessset/diskless/nfs_module.py
+++ b/bluebanquise-disklessset/diskless/nfs_module.py
@@ -41,6 +41,7 @@ class NfsStagingImage(Image):
     # Class constructor
     def __init__(self, name, password=None, kernel=None, additional_packages=None, release_version=None):
         super().__init__(name, password, kernel, additional_packages, release_version)
+        self.is_mounted=False
 
     # Create new staging image
     def create_new_image(self, password, kernel, additional_packages, release_version):
@@ -254,6 +255,7 @@ class NfsGoldenImage(Image):
     # Class constructor
     def __init__(self, name, staging_image=None):
         super().__init__(name, staging_image)
+        self.is_mounted=False
 
     # Create new golden image
     def create_new_image(self, staging_image):


### PR DESCRIPTION
adding self.is_mounted=False to NfsGoldenImage and NfsStagingImage because it makes no sense for Nfs Images and its checked on the image_manager (so, it will workaround it for now):
```
 # Checks if image is really mounted as per is_mounted = True
            if image.is_mounted:
                if not os.path.ismount(image.MOUNT_DIRECTORY):
                    image.is_mounted = False
                    image.register_image()
```
Causing the following Error:

[-] No nfs staging images. Golden image creation require an nfs staging image.
 1 - Generate a new nfs staging image
 2 - Generate a new nfs golden image from a staging image
 3 - Manage nodes of a golden image
-->: 2
ERROR:root:'NfsStagingImage' object has no attribute 'is_mounted'

[-] No nfs staging images. Golden image creation require an nfs staging image.
 1 - Generate a new nfs staging image
 2 - Generate a new nfs golden image from a staging image
 3 - Manage nodes of a golden image